### PR TITLE
Change default maintenance trigger to 20 minutes

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -25,7 +25,7 @@ const config = {
   fetchRetryTime: 300,
 
   // If snapshots are old by this amount, trigger maintenace message
-  maintenanceAge: 600,
+  maintenanceAge: 1200,
 
   // Array indices for CPU usage
   cpuKeys: {


### PR DESCRIPTION
When restarting after a crash, it takes around 10 minutes to load in all the new data. This change prevents the maintenance message from appearing prematurely.