### PR TITLE
Fix warning delay

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -665,7 +665,6 @@ class App extends React.Component {
       historyDataWindow,
       apiData,
     } = this.state;
-
     if (historyData.length < 3) {
       this.historyTimeJump();
     } else {
@@ -753,7 +752,9 @@ class App extends React.Component {
             // If the last snapshot has been read
             if (i === requestDataTimes.length - 1) {
               if (nVal > historyDataTimes.length) {
-                that.setState({ historyData: historyDataTemp });
+                that.setState({ historyData: historyDataTemp },
+                  () => this.getWarnings()
+                  );
               } else if (nVal < 200) {
                 that.setState({
                   historyData: historyDataTemp,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -610,6 +610,9 @@ class App extends React.Component {
   postFetch() {
     this.setGpuLayout()
     this.updateHistoryData()
+    this.setState({
+      systemUsage: this.getSystemUsage(),
+    })
   }
 
   getWarnings() {
@@ -621,10 +624,10 @@ class App extends React.Component {
 
     const warnings = generateWarnings(snapshotTime, historyData)
     const warnedUsers = getWarnedUsers(warnings, apiData.jobs)
+
     this.setState({
       warnings: warnings,
       warnedUsers: warnedUsers,
-      systemUsage: this.getSystemUsage(),
     })
 
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -608,20 +608,22 @@ class App extends React.Component {
   }
 
   postFetch() {
+    this.setGpuLayout()
+    this.updateHistoryData()
+  }
+
+  getWarnings() {
     const {
       apiData,
       snapshotTime,
-      historyData,
+      historyData
     } = this.state
 
-    this.setGpuLayout()
-    this.updateHistoryData()
-
     const warnings = generateWarnings(snapshotTime, historyData)
-
+    const warnedUsers = getWarnedUsers(warnings, apiData.jobs)
     this.setState({
       warnings: warnings,
-      warnedUsers: getWarnedUsers(warnings, apiData.jobs),
+      warnedUsers: warnedUsers,
       systemUsage: this.getSystemUsage(),
     })
 
@@ -693,7 +695,9 @@ class App extends React.Component {
 
       // Update, before putting past values in (if history is too short)
       if (changed) {
-        this.setState({ historyData: newHistoryData });
+        this.setState({ historyData: newHistoryData },
+          () => this.getWarnings()
+          );
       }
     }
   }

--- a/frontend/src/UserPiePlot.jsx
+++ b/frontend/src/UserPiePlot.jsx
@@ -19,6 +19,7 @@ export default class UserPiePlot extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     const {
       timestamp,
+      warnedUsers,
     } = this.props;
 
     const {
@@ -30,7 +31,9 @@ export default class UserPiePlot extends React.Component {
 
     if (nextProps.timestamp !== timestamp) {
       return true
-    } if (nextState.usagePieActiveIndex !== usagePieActiveIndex) {
+    } if (nextProps.warnedUsers !== warnedUsers) {
+      return true
+    }if (nextState.usagePieActiveIndex !== usagePieActiveIndex) {
       return true
     } if (nextState.usagePieSelectedIndex !== usagePieSelectedIndex) {
       return true


### PR DESCRIPTION
Bug: interface was delaying when to show warned users.

Resolved by forcing update after history data is downloaded, and adding to shouldComponentUpdate.